### PR TITLE
Upgrade Foursquare to use v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need to setup a few API keys for this project to be setup correctly otherwis
 
 - [Unsplash Access Key](https://unsplash.com/documentation)
 - [Airtable Base and API Key](https://www.airtable.com/api)
-- [Foursquare Client ID and Client Secret Key](https://developer.foursquare.com/)
+- [Foursquare API Key](https://developer.foursquare.com/docs/migrate-to-newest-places-api-version#generating-api-keys)
 
 For that, you can create a .env.local file in your project as [shown in docs](https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables) that will look like this:
 
@@ -32,8 +32,7 @@ For that, you can create a .env.local file in your project as [shown in docs](ht
 AIRTABLE_BASE_KEY=<REPLACE THIS>
 AIRTABLE_API_KEY=<REPLACE THIS>
 NEXT_PUBLIC_UNSPLASH_ACCESS_KEY=<REPLACE THIS>
-NEXT_PUBLIC_FOURSQUARE_CLIENT_SECRET=<REPLACE THIS>
-NEXT_PUBLIC_FOURSQUARE_CLIENT_ID=<REPLACE THIS>
+NEXT_PUBLIC_FOURSQUARE_API_KEY=<REPLACE THIS>
 ```
 
 You can retrieve the above environment values by referring their docs linked above.

--- a/lib/coffee-stores.js
+++ b/lib/coffee-stores.js
@@ -9,7 +9,7 @@ const unsplashApi = createApi({
 });
 
 const getUrlForCoffeeStores = (latLong, query, limit) => {
-  return `https://api.foursquare.com/v2/venues/search?ll=${latLong}&query=${query}&client_id=${process.env.NEXT_PUBLIC_FOURSQUARE_CLIENT_ID}&client_secret=${process.env.NEXT_PUBLIC_FOURSQUARE_CLIENT_SECRET}&v=20210525&limit=${limit}`;
+  return `https://api.foursquare.com/v3/places/nearby?ll=${latLong}&query=${query}&limit=${limit}`;
 };
 
 const getListOfCoffeeStorePhotos = async () => {
@@ -23,18 +23,23 @@ const getListOfCoffeeStorePhotos = async () => {
 
 export const fetchCoffeeStores = async (
   latLong = "43.65267326999575,-79.39545615725015",
-  limit = 6
+  limit = 8
 ) => {
   const photos = await getListOfCoffeeStorePhotos();
   const response = await fetch(
-    getUrlForCoffeeStores(latLong, "coffee stores", limit)
+    getUrlForCoffeeStores(latLong, "coffee stores", limit),
+    {
+      "headers": {
+        'Authorization': process.env.NEXT_PUBLIC_FOURSQUARE_API_KEY
+      }
+    }
   );
   const data = await response.json();
 
-  return data.response.venues?.map((venue, idx) => {
+  return data.results?.map((venue, idx) => {
     return {
       // ...venue,
-      id: venue.id,
+      id: venue.fsq_id,
       address: venue.location.address || "",
       name: venue.name,
       neighbourhood:


### PR DESCRIPTION
Recently Foursquare upgraded from v2 to v3 but also introduced some breaking changes.  After following [the migration document](https://developer.foursquare.com/docs/migrate-to-newest-places-api-version), here are the changes we need to make.

Limit needed to update to 8 from 6 as only limit - 2 coffee stores return typically.

Also needed to update the environment variables on Vercel and Netlify and now introduced a new variable called: NEXT_PUBLIC_FOURSQUARE_API_KEY and created a new API key by following [docs](https://developer.foursquare.com/docs/migrate-to-newest-places-api-version#generating-api-keys) and set it on both environments!