### PR TITLE
Fix Security vulnerability with node-fetch that requires manual review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,33 @@
           "version": "14.17.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
           "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -1320,9 +1347,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
     "next": {
       "version": "12.0.7",
@@ -1389,12 +1416,36 @@
         "util": "0.12.4",
         "vm-browserify": "1.1.2",
         "watchpack": "2.3.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-html-parser": {
       "version": "1.4.9",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "preinstall": "npx npm-force-resolutions",
     "build": "next build",
     "start": "next start"
   },
@@ -15,5 +16,8 @@
     "react-dom": "^17.0.2",
     "swr": "^0.5.6",
     "unsplash-js": "^7.0.11"
+  },
+  "resolutions": {
+    "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   }
 }


### PR DESCRIPTION
Typically when we run `npm run audit` you will see vulnerabilities that should get fixed with `npm audit fix` as the packages themselves have released a new version and fixed it but in some cases you will have to manually review them for example,

<img width="729" alt="Screen Shot 2022-01-23 at 2 30 10 PM" src="https://user-images.githubusercontent.com/2559673/150694862-12ffb8e0-12ab-49e7-8240-0fb8c7edd2cc.png">

Notice how it says "manual review". This means npm audit fix did not find a new package that resolves this issue. In the above screenshot, it's `node-fetch` that has a vulnerability that requires us to manually review the issue and make sure we are aware of the problem. If you look in package.json, we are not using `node-fetch` but if you look in the screenshot, it says that `next > node-fetch` is using it that means next.js package should resolve the vulnerability.

If you are wondering how we can override a package version when we have no control on that package. Well, here are the steps we should take to resolve it.

- Visit the Audit guide: 
  just like it says in the screenshot https://go.npm.me/audit-guide and review the steps we need to take. We need to make sure we fully understand the issue
  
- Visit the Next.js Github issues and see if Next.js has any plans to resolve this
  If you search for `npm` in https://github.com/vercel/next.js/issues?q=is%3Aissue+npm, It turns out there is an issue: https://github.com/vercel/next.js/issues/33556 that talks about fixing this. If you review the PR attached to the issue, here it is: https://github.com/vercel/next.js/pull/33466 then they are mainly upgrading `node-fetch` to 2.7.1 and that change is coming out in the next stable release. This means they have already fixed it but haven't released it to us yet.

Now we have 2 options:
1) Lets wait for the new stable version of Next.js as they are fixing it anyways
2) Let's override the next.js package with a node-fetch 2.7.1

We can do (2) until (1) comes out and we can remove (2) altogether.

For overriding a dependancy that a package is using (in our case Next.js is using node-fetch) then we can use `npm resolutions` that allows us to specify how to override a package. In short, we are telling package.json to give priority to "`resolutions`" package over Next.js dependancy package. 

Just to make sure that when we run `npm install` or anyone on your team does when they clone this repo, we also want to make sure that `node-fetch: 2.6.7` is installed so for that, we can add a pre-install script which will run before `npm install`.