### PR TITLE
Upgrade Next Version that auto resolves security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,11 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -264,9 +269,12 @@
       "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA=="
     },
     "swr": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.0.tgz",
-      "integrity": "sha512-C3IXeKOREn0jQ1ewXRENE7ED7jjGbFTakwB64eLACkCqkF/A0N2ckvpCTftcaSYi5yV36PzoehgVCOVRmtECcA=="
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.5.6.tgz",
+      "integrity": "sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==",
+      "requires": {
+        "dequal": "2.0.2"
+      }
     },
     "unsplash-js": {
       "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -4,20 +4,16 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "preinstall": "npx npm-force-resolutions",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
     "airtable": "^0.11.1",
     "classnames": "^2.3.1",
-    "next": "^12.0.7",
+    "next": "^12.0.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "swr": "^1.2.0",
     "unsplash-js": "^7.0.11"
-  },
-  "resolutions": {
-    "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   }
 }


### PR DESCRIPTION
- Next.js has a new version released: https://github.com/vercel/next.js/releases/tag/v12.0.9 so upgrading to latest
- Previous Next.js version introduced a security vulnerability that is fixed in this version as well. Details on the previous security vulnerability: https://github.com/kulkarniankita/discover-coffee-stores/pull/6
- Removing the temp fix introduced to resolve the vulnerability since the new update of Next.js resolves it